### PR TITLE
return sf from edit_map

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mapedit
 Title: Interactive Editing of Spatial Data in R
 Description: What the package does (one paragraph).
-Version: 0.0.1
-Date: 2017-01-24
+Version: 0.0.2
+Date: 2017-04-03
 Authors@R: c(
     person("Tim", "Appelhans", role = c("aut", "cre"), email = "tim.appelhans@gmail.com"),
     person("Kenton", "Russell", role = c("aut"))
@@ -13,11 +13,13 @@ License: MIT + file LICENSE
 Depends:
     R (>= 3.1.0)
 Imports:
+    dplyr,
     htmltools (>= 0.3),
     jsonlite,
     leaflet,
     leaflet.extras,
     miniUI,
+    sf,
     shiny
 Suggests:
     mapview

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,10 @@
+# mapedit 0.0.2
+
+* add dependency on `dplyr`
+* add dependency on `sf`
+* `edit_map()` now returns `sf` instead of `geojson` by default.  Toggle
+    behavior with the `sf` argument.
+
+# mapedit 0.0.1
+
+* first release with proof-of-concept functionality

--- a/R/edit.R
+++ b/R/edit.R
@@ -16,7 +16,7 @@ edit_map <- function(x, ...) {
 }
 
 #' @export
-edit_map.leaflet <- function(x = NULL, targetLayerId = NULL) {
+edit_map.leaflet <- function(x = NULL, targetLayerId = NULL, sf = TRUE) {
   stopifnot(!is.null(x), inherits(x, "leaflet"))
 
   stopifnot(
@@ -95,14 +95,46 @@ edit_map.leaflet <- function(x = NULL, targetLayerId = NULL) {
     })
 
     shiny::observeEvent(input$done, {
-      shiny::stopApp(
-        list(
-          drawn = drawn,
-          edited = edited_all,
-          deleted = deleted_all,
-          finished = finished
-        )
+      # collect all of the the features into a list
+      #  by action
+      returnlist <- list(
+        drawn = drawn,
+        edited = edited_all,
+        deleted = deleted_all,
+        finished = finished
       )
+      # if sf argument is TRUE then convert to simple features
+      if(sf) {
+        returnlist <- lapply(
+          returnlist,
+          function(gj) {
+            # ignore empty action types to prevent error
+            #   handle in the helper functions?
+            if(length(gj) == 0) { return() }
+
+            # deleted is often a FeatureCollection
+            #  which requires special treatment
+            if(gj[[1]]$type == "FeatureCollection") {
+              return(
+                combine_list_of_sf(
+                  lapply(
+                    gj[[1]]$features,
+                    function(feature) {
+                      st_as_sf.geo_list(feature)
+                    }
+                  )
+                )
+              )
+            }
+
+            combine_list_of_sf(
+              lapply(gj, st_as_sf.geo_list)
+            )
+          }
+        )
+      }
+      # return geojson or sf list
+      shiny::stopApp(returnlist)
     })
 
     shiny::observeEvent(input$cancel, { shiny::stopApp (NULL) })

--- a/R/edit_map_return_sf.R
+++ b/R/edit_map_return_sf.R
@@ -67,20 +67,6 @@ fix_geojson_coords <- function(ft) {
   ft
 }
 
-convert_geojson_coords <- function(gj) {
-  feats <- lapply(
-    gj,
-    function(ft) {
-      ft <- fix_geojson_coords(ft)
-      st_as_sfc.geo_list(ft$geometry)
-    }
-  )
-
-  sf::st_sf(
-    features = do.call(sf::st_sfc, unlist(feats, recursive=FALSE))
-  )
-}
-
 #' @keywords internal
 combine_list_of_sf <- function(sf_list) {
   props <- dplyr::bind_rows(

--- a/R/edit_map_return_sf.R
+++ b/R/edit_map_return_sf.R
@@ -33,9 +33,9 @@ st_as_sf.geo_list = function(x, ...) {
   geom_sf <- st_as_sfc.geo_list(x$geometry)
   # if props are empty then we need to handle differently
   if(nrow(props) == 0 ) {
-    return(sf::st_sf(feature=geom_sf))
+    return(sf::st_sf(feature=geom_sf, crs = sf::st_crs(4326)))
   } else {
-    return(sf::st_sf(props, feature=geom_sf))
+    return(sf::st_sf(props, feature=geom_sf, crs = sf::st_crs(4326)))
   }
 }
 
@@ -85,6 +85,7 @@ combine_list_of_sf <- function(sf_list) {
     props,
     feature = sf::st_sfc(
       unlist(lapply(sf_list, function(x) x$feature), recursive=FALSE)
-    )
+    ),
+    crs = sf::st_crs(4326)
   )
 }

--- a/inst/experiments/edit_map_return_sf.R
+++ b/inst/experiments/edit_map_return_sf.R
@@ -29,7 +29,12 @@ st_as_sf.geo_list = function(x, ...) {
   )
 
   geom_sf <- st_as_sfc.geo_list(x$geometry)
-  st_sf(props, feature=geom_sf)
+  # if props are empty then we need to handle differently
+  if(nrow(props) == 0 ) {
+    return(st_sf(feature=geom_sf))
+  } else{
+    return(st_sf(props, feature=geom_sf))
+  }
 }
 
 

--- a/inst/experiments/edit_map_return_sf.R
+++ b/inst/experiments/edit_map_return_sf.R
@@ -16,13 +16,20 @@ st_as_sfc.geo_list = function(x, ...) {
 }
 
 st_as_sf.geo_list = function(x, ...) {
-  x = switch(x$type,
-             Feature = st_sf(
-               t(unlist(x$properties)),
-               feature = st_as_sfc(x$geometry)
-             ),
-             stop("should be of type 'Feature'")
+  if(x$type != "Feature") stop("should be of type 'Feature'", call.=FALSE)
+
+  x <- fix_geojson_coords(x)
+
+  props <- do.call(
+    data.frame,
+    modifyList(
+      Filter(Negate(is.null), x$properties),
+      list(stringsAsFactors=FALSE)
+    )
   )
+
+  geom_sf <- st_as_sfc.geo_list(x$geometry)
+  st_sf(props, feature=geom_sf)
 }
 
 

--- a/inst/experiments/edit_map_return_sf.R
+++ b/inst/experiments/edit_map_return_sf.R
@@ -1,0 +1,68 @@
+# test geojson conversion functions
+library(sf)
+st_as_sfc.geo_list = function(x, ...) {
+  x = switch(x$type,
+             Point = st_point(x$coordinates),
+             MultiPoint = st_multipoint(x$coordinates),
+             LineString = st_linestring(x$coordinates),
+             MultiLineString = st_multilinestring(x$coordinates),
+             Polygon = st_polygon(x$coordinates),
+             MultiPolygon = st_multipolygon(x$coordinates),
+             GeometryCollection = st_geometrycollection(
+               lapply(x$geometries, function(y) st_as_sfc.geo_list(y)[[1]])),
+             stop("unknown class")
+  )
+  st_sfc(x, crs = st_crs(4326))
+}
+
+st_as_sf.geo_list = function(x, ...) {
+  x = switch(x$type,
+             Feature = st_sf(
+               t(unlist(x$properties)),
+               feature = st_as_sfc(x$geometry)
+             ),
+             stop("should be of type 'Feature'")
+  )
+}
+
+
+fix_geojson_coords <- function(ft) {
+
+  if(ft$geometry$type == "Point") {
+    ft$geometry$coordinates <- unlist(ft$geometry$coordinates)
+  }
+
+  if(ft$geometry$type == "LineString") {
+    ft$geometry$coordinates <- matrix(
+      unlist(ft$geometry$coordinates),
+      ncol = 2,
+      byrow = TRUE
+    )
+  }
+
+  if(!(ft$geometry$type %in% c("Point", "LineString"))) {
+    ft$geometry$coordinates <- list(
+      matrix(
+        unlist(ft$geometry$coordinates),
+        ncol = 2,
+        byrow = TRUE
+      )
+    )
+  }
+
+  ft
+}
+
+convert_geojson_coords <- function(gj) {
+  feats <- lapply(
+    gj,
+    function(ft) {
+      ft <- fix_geojson_coords(ft)
+      st_as_sfc.geo_list(ft$geometry)
+    }
+  )
+
+  st_sf(
+    features = do.call(st_sfc, unlist(feats, recursive=FALSE))
+  )
+}

--- a/inst/experiments/edit_map_return_sf.R
+++ b/inst/experiments/edit_map_return_sf.R
@@ -78,3 +78,20 @@ convert_geojson_coords <- function(gj) {
     features = do.call(st_sfc, unlist(feats, recursive=FALSE))
   )
 }
+
+# requires dependency on dplyr
+#  need to make a decision here if ok
+#  otherwise will need to make bind_rows equivalent
+combine_list_of_sf <- function(sf_list) {
+  props <- lapply(
+    sf_list, function(x) x %>% as.data.frame() %>% select(-feature)
+  ) %>%
+    dplyr::bind_rows()
+
+  st_sf(
+    props,
+    feature = st_sfc(
+      unlist(lapply(sf_list, function(x) x$feature), recursive=FALSE)
+    )
+  )
+}

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -84,6 +84,7 @@ nwy_sf3 <- st_sf(
     unlist(lapply(nwy_sf2, function(x) x$feature), recursive=FALSE)
   )
 )
+leaflet(nwy_sf3) %>% addMarkers(popup=~description) %>% addTiles()
 
 props <- lapply(
   me_sf2, function(x) x %>% as.data.frame() %>% select(-feature)
@@ -96,3 +97,4 @@ me_sf3 <- st_sf(
     unlist(lapply(me_sf2, function(x) x$feature), recursive=FALSE)
   )
 )
+leaflet(me_sf3) %>% addPolygons(popup=~feature_type) %>% addTiles()

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -57,8 +57,6 @@ plot(me_sf)
 # now try to add in properties
 #  this does not seem critical at this point
 #  but will be necessary to be considered complete
-props <- lapply(me_gj, function(x) do.call(data.frame, list(x$properties)))
-sf:::cbind.sf(me_sf, dplyr::bind_rows(props))
-
-
+props <- lapply(me_gj, function(x) do.call(data.frame, list(x$properties, stringsAsFactors=FALSE)))
+sf:::cbind.sf(me_sf, do.call(rbind,props))
 

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -98,3 +98,9 @@ me_sf3 <- st_sf(
   )
 )
 leaflet(me_sf3) %>% addPolygons(popup=~feature_type) %>% addTiles()
+
+
+# test with randgeo
+randgeo::geo_point(10) %>%
+  {.$features} %>%
+  lapply(function(x) st_as_sf.geo_list(x))

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -40,6 +40,7 @@ do.call(rbind, feats)
 
 
 nwy_sf <- convert_geojson_coords(nwy_map$features)
+plot(nwy_sf)
 
 library(leaflet)
 library(mapedit)
@@ -48,6 +49,7 @@ library(mapedit)
 me_gj <- edit_map(leaflet())$finished
 # coordinates from edit_map not in proper form
 #  so added a fix function
-convert_geojson_coords(
+me_sf <- convert_geojson_coords(
   lapply(me_gj,function(x) list(geometry = x$geometry))
 )
+plot(me_sf)

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -73,30 +73,10 @@ me_sf2 <- lapply(
 
 # the easiest solution would be to use dplyr
 #   but would require a dependency on dplyr
-props <- lapply(
-  nwy_sf2, function(x) x %>% as.data.frame() %>% select(-feature)
-) %>%
-  dplyr::bind_rows()
-
-nwy_sf3 <- st_sf(
-  props,
-  feature = st_sfc(
-    unlist(lapply(nwy_sf2, function(x) x$feature), recursive=FALSE)
-  )
-)
+nwy_sf3 <- combine_list_of_sf(nwy_sf2)
 leaflet(nwy_sf3) %>% addMarkers(popup=~description) %>% addTiles()
 
-props <- lapply(
-  me_sf2, function(x) x %>% as.data.frame() %>% select(-feature)
-) %>%
-  dplyr::bind_rows()
-
-me_sf3 <- st_sf(
-  props,
-  feature = st_sfc(
-    unlist(lapply(me_sf2, function(x) x$feature), recursive=FALSE)
-  )
-)
+me_sf3 <- combine_list_of_sf(me_sf2)
 leaflet(me_sf3) %>% addPolygons(popup=~feature_type) %>% addTiles()
 
 
@@ -104,19 +84,7 @@ leaflet(me_sf3) %>% addPolygons(popup=~feature_type) %>% addTiles()
 randgeo::geo_point(10) %>%
   {.$features} %>%
   lapply(function(x) st_as_sf.geo_list(x)) %>%
-  {
-    props <- lapply(
-      ., function(x) x %>% as.data.frame() %>% select(-feature)
-    ) %>%
-      dplyr::bind_rows()
-
-    st_sf(
-      props,
-      feature = st_sfc(
-        unlist(lapply(., function(x) x$feature), recursive=FALSE)
-      )
-    )
-  } %>%
+  combine_list_of_sf %>%
   leaflet() %>%
     addMarkers() %>%
     addTiles()
@@ -130,17 +98,5 @@ list(
   {lapply(., function(x) x$features)} %>%
   unlist(recursive = FALSE) %>%
   lapply(function(x) st_as_sf.geo_list(x)) %>%
-  {
-    props <- lapply(
-      ., function(x) x %>% as.data.frame() %>% select(-feature)
-    ) %>%
-      dplyr::bind_rows()
-
-    st_sf(
-      props,
-      feature = st_sfc(
-        unlist(lapply(., function(x) x$feature), recursive=FALSE)
-      )
-    )
-  } %>%
+  combine_list_of_sf() %>%
   plot()

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -1,0 +1,53 @@
+library(geojsonio)
+
+file <- system.file("examples", "norway_maple.kml", package = "geojsonio")
+nwy_map <- geojson_read(as.location(file), what = "list")
+listviewer::jsonedit(nwy_map)
+
+pt <- nwy_map$features[[1]]$geometry
+class(pt) <- "geo_list"
+
+
+p_list <- lapply(list(c(3.2,4), c(3,4.6), c(3.8,4.4)), st_point)
+pt_sfc <- st_sfc(p_list)
+pt_sf <- st_sf(x = c("a", "b", "c"), pt_sfc)
+
+# use geojsonio to convert sf to geojson
+gj_pt_sf <- geojsonio::geojson_list(pt_sf)
+
+# start by trying to convert a single geojson feature to s
+feat <- gj_pt_sf$features[[1]]
+
+# manually translate one geojson feature
+one_feat <- st_sf(
+  feat$properties,
+  st_as_sfc.geo_list(feat$geometry)
+)
+
+
+# now try to convert all of the geojson features
+feats <- lapply(
+  gj_pt_sf$features,
+  function(ft) {
+    st_sf(
+      ft$properties,
+      st_as_sfc.geo_list(ft$geometry)
+    )
+  }
+)
+
+do.call(rbind, feats)
+
+
+nwy_sf <- convert_geojson_coords(nwy_map$features)
+
+library(leaflet)
+library(mapedit)
+# draw something with mapedit::edit_map
+#   and try to convert to sf
+me_gj <- edit_map(leaflet())$finished
+# coordinates from edit_map not in proper form
+#  so added a fix function
+convert_geojson_coords(
+  lapply(me_gj,function(x) list(geometry = x$geometry))
+)

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -39,6 +39,21 @@ feats <- lapply(
 do.call(rbind, feats)
 
 
+
+convert_geojson_coords <- function(gj) {
+  feats <- lapply(
+    gj,
+    function(ft) {
+      ft <- fix_geojson_coords(ft)
+      st_as_sfc.geo_list(ft$geometry)
+    }
+  )
+
+  sf::st_sf(
+    features = do.call(sf::st_sfc, unlist(feats, recursive=FALSE))
+  )
+}
+
 nwy_sf <- convert_geojson_coords(nwy_map$features)
 plot(nwy_sf)
 

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -103,4 +103,44 @@ leaflet(me_sf3) %>% addPolygons(popup=~feature_type) %>% addTiles()
 # test with randgeo
 randgeo::geo_point(10) %>%
   {.$features} %>%
-  lapply(function(x) st_as_sf.geo_list(x))
+  lapply(function(x) st_as_sf.geo_list(x)) %>%
+  {
+    props <- lapply(
+      ., function(x) x %>% as.data.frame() %>% select(-feature)
+    ) %>%
+      dplyr::bind_rows()
+
+    st_sf(
+      props,
+      feature = st_sfc(
+        unlist(lapply(., function(x) x$feature), recursive=FALSE)
+      )
+    )
+  } %>%
+  leaflet() %>%
+    addMarkers() %>%
+    addTiles()
+
+
+# test with randgeo
+list(
+  randgeo::geo_point(10),
+  randgeo::geo_polygon(10)
+) %>%
+  {lapply(., function(x) x$features)} %>%
+  unlist(recursive = FALSE) %>%
+  lapply(function(x) st_as_sf.geo_list(x)) %>%
+  {
+    props <- lapply(
+      ., function(x) x %>% as.data.frame() %>% select(-feature)
+    ) %>%
+      dplyr::bind_rows()
+
+    st_sf(
+      props,
+      feature = st_sfc(
+        unlist(lapply(., function(x) x$feature), recursive=FALSE)
+      )
+    )
+  } %>%
+  plot()

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -58,7 +58,7 @@ plot(me_sf)
 #  this does not seem critical at this point
 #  but will be necessary to be considered complete
 props <- lapply(me_gj, function(x) do.call(data.frame, list(x$properties)))
-cbind(me_sf, props)
-cbind(me_sf, dplyr::bind_rows(props))
+sf:::cbind.sf(me_sf, dplyr::bind_rows(props))
+
 
 

--- a/inst/experiments/edit_map_return_sf_tests.R
+++ b/inst/experiments/edit_map_return_sf_tests.R
@@ -53,3 +53,12 @@ me_sf <- convert_geojson_coords(
   lapply(me_gj,function(x) list(geometry = x$geometry))
 )
 plot(me_sf)
+
+# now try to add in properties
+#  this does not seem critical at this point
+#  but will be necessary to be considered complete
+props <- lapply(me_gj, function(x) do.call(data.frame, list(x$properties)))
+cbind(me_sf, props)
+cbind(me_sf, dplyr::bind_rows(props))
+
+

--- a/inst/experiments/sf_leafletdraw_intersect.R
+++ b/inst/experiments/sf_leafletdraw_intersect.R
@@ -50,3 +50,8 @@ leaflet() %>%
   addCircles(data=st_difference(pts_sf, shape_sfc), color = "red") %>%
   addPolygons(data=shape_sfc) %>%
   addTiles()
+
+
+# now do same as above but with mapedit::edit_map
+library(mapedit)
+me_edits <- edit_map(lf)


### PR DESCRIPTION
This is a work-in-progress toward returning `sf` from `edit_map()`.  It seems to work, but is fairly ugly.  Would be slightly easier with solution for https://github.com/edzer/sfr/issues/185, but `Feature` and `FeatureCollection` will be tricky, so I elected to do within `mapedit` for now.

I added dependencies to `dplyr` and `sf`.   @tim-salabim, please let me know if there are problems with these newly introduced dependencies.