### PR TITLE
add original attribute and improve playback

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -205,6 +205,7 @@ editFeatures.sf = function(
   # return merged features
   if(record==TRUE) {
     attr(merged, "recorder") <- attr(crud, "recorder", exact=TRUE)
+    attr(merged, "original") <- x
   }
   return(merged)
 }


### PR DESCRIPTION
#37, #41 

* add original `attribute` for `editFeatures()`
* add better error handling in `playback`
* fix bug with edited points since flubber cannot interpolate non-polygon