### PR TITLE
feature/geometry naming consistent with st_read

### DIFF
--- a/R/edit_map_return_sf.R
+++ b/R/edit_map_return_sf.R
@@ -88,7 +88,7 @@ combine_list_of_sf <- function(sf_list) {
 
   sf::st_sf(
     props,
-    feature = sf::st_sfc(
+    geometry = sf::st_sfc(
       unlist(lapply(sf_list, function(x) sf::st_geometry(x)), recursive=FALSE)
     ),
     crs = sf::st_crs(4326)


### PR DESCRIPTION
When reading / writing geometries with st_read and st_write, I end up with feature collections with the feature geometry named "geometry".

By contrast, when I create a feature collection created with editMap(), I end up with a feature collection where the feature geometry is named "feature". It's a minor annoyance, but this naming inconsistency results in an extra step when I want to rbind() two such simple feature collections. (BTW, is there a reason this is editMap as opposed to mapEdit like mapView?)

Example of the issue this resolves:
```
foo <- editMap()
names(foo)            # [1] "X_leaflet_id" "feature_type" "geometry"
tmp <- tempfile(fileext = ".geojson")
st_write(foo, tmp)
bar <- st_read(tmp)
names(bar)           # [1] "X_leaflet_id" "feature_type" "feature"
rbind(foo, bar)       # Error in match.names(clabs, names(xi)) : 
                      # names do not match previous names
```
