### PR TITLE
0.3.2 suite of bug fixes and improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: mapedit
 Title: Interactive Editing of Spatial Data in R
 Description: Suite of interactive functions and helpers for selecting and editing
     geospatial data.
-Version: 0.3.1
-Date: 2017-07-01
+Version: 0.3.2
+Date: 2017-07-12
 Authors@R: c(
     person("Tim", "Appelhans", role = c("aut", "cre"), email = "tim.appelhans@gmail.com"),
     person("Kenton", "Russell", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,9 @@
 
 * remove internally added `edit_id` column in editFeatures return
 
-* cast edits back to their original type
+* cast edits back to their original type.  See [discussion](https://github.com/r-spatial/mapedit/issues/48)
+
+* fix merge_edit to only consider last edit when there are multiple edits per layerId
 
 # mapedit 0.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# mapedit 0.3.2
+
+### Bug Fix
+
+* polygons of `length > 1` not handled correctly.  See [discussion](https://github.com/r-spatial/mapedit/issues/48).
+
 # mapedit 0.3.1
 
 ### Bug Fix

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * polygons of `length > 1` not handled correctly.  See [discussion](https://github.com/r-spatial/mapedit/issues/48).
 
+* remove internally added `edit_id` column in editFeatures return
+
+* cast edits back to their original type
+
 # mapedit 0.3.1
 
 ### Bug Fix

--- a/R/edit.R
+++ b/R/edit.R
@@ -207,7 +207,7 @@ editFeatures.sf = function(
     attr(merged, "recorder") <- attr(crud, "recorder", exact=TRUE)
     attr(merged, "original") <- x
   }
-  return(dplyr::select(merged, -edit_id))
+  return(dplyr::select_(merged, "-edit_id"))
 }
 
 #' @name editFeatures

--- a/R/edit.R
+++ b/R/edit.R
@@ -202,12 +202,15 @@ editFeatures.sf = function(
     init = x
   )
 
+  merged <- dplyr::select_(merged, "-edit_id")
+
   # return merged features
   if(record==TRUE) {
     attr(merged, "recorder") <- attr(crud, "recorder", exact=TRUE)
     attr(merged, "original") <- x
   }
-  return(dplyr::select_(merged, "-edit_id"))
+
+  merged
 }
 
 #' @name editFeatures

--- a/R/edit.R
+++ b/R/edit.R
@@ -207,7 +207,7 @@ editFeatures.sf = function(
     attr(merged, "recorder") <- attr(crud, "recorder", exact=TRUE)
     attr(merged, "original") <- x
   }
-  return(merged)
+  return(dplyr::select(merged, -edit_id))
 }
 
 #' @name editFeatures

--- a/R/edit_map_return_sf.R
+++ b/R/edit_map_return_sf.R
@@ -24,23 +24,7 @@ st_as_sf.geo_list = function(x, ...) {
     stop("should be of type 'Feature'", call.=FALSE)
   }
 
-  x <- fix_geojson_coords(x)
-
-  #props <- do.call(
-  #  data.frame,
-  #  modifyList(
-  #    Filter(Negate(is.null), x$properties),
-  #    list(stringsAsFactors=FALSE)
-  #  )
-  #)
-
   geom_sf <- st_as_sfc.geo_list(x)
-  # if props are empty then we need to handle differently
-  #if(nrow(props) == 0 ) {
-  #  return(sf::st_sf(feature=geom_sf, crs = sf::st_crs(4326)))
-  #} else {
-  #  return(sf::st_sf(props, feature=geom_sf, crs = sf::st_crs(4326)))
-  #}
 }
 
 #' @keywords internal
@@ -59,12 +43,15 @@ fix_geojson_coords <- function(ft) {
   }
 
   if(!(ft$geometry$type %in% c("Point", "LineString"))) {
-    ft$geometry$coordinates <- list(
-      matrix(
-        unlist(ft$geometry$coordinates),
-        ncol = 2,
-        byrow = TRUE
-      )
+    ft$geometry$coordinates <- lapply(
+      ft$geometry$coordinates,
+      function(coords) {
+        matrix(
+          unlist(ft$geometry$coordinates),
+          ncol = 2,
+          byrow = TRUE
+        )
+      }
     )
   }
 

--- a/R/merge.R
+++ b/R/merge.R
@@ -37,13 +37,13 @@ merge_edit <- function(
   matched_id_rows = which(orig_ids %in% edit_ids)
 
   # cast edits to original type
-  st_geometry(edits) <- st_sfc(mapply(
+  sf::st_geometry(edits) <- sf::st_sfc(mapply(
     function(ed, type) {
       sf::st_cast(ed, type)
     },
-    st_geometry(edits),
+    sf::st_geometry(edits),
     as.character(
-      st_geometry_type(
+      sf::st_geometry_type(
         sf::st_geometry(orig2)
       )[matched_id_rows]
     ),

--- a/R/merge.R
+++ b/R/merge.R
@@ -32,6 +32,16 @@ merge_edit <- function(
   orig2 <- orig
 
   orig_ids = orig2[[names(by)[1]]]
+
+  # only get last edit for each layer id since
+  #   intermediate edits are not important for the final result
+  edits <- aggregate(
+    x = edits,
+    by = list(edits$layerId),
+    FUN = function(x){tail(x,1)},
+    do_union = FALSE
+  )
+
   edit_ids = edits[,by[[1]], drop=TRUE]
 
   matched_id_rows = which(orig_ids %in% edit_ids)

--- a/R/merge.R
+++ b/R/merge.R
@@ -36,6 +36,20 @@ merge_edit <- function(
 
   matched_id_rows = which(orig_ids %in% edit_ids)
 
+  # cast edits to original type
+  st_geometry(edits) <- st_sfc(mapply(
+    function(ed, type) {
+      sf::st_cast(ed, type)
+    },
+    st_geometry(edits),
+    as.character(
+      st_geometry_type(
+        sf::st_geometry(orig2)
+      )[matched_id_rows]
+    ),
+    SIMPLIFY = FALSE
+  ))
+
   sf::st_geometry(orig2)[matched_id_rows] <- sf::st_geometry(edits)
   orig2
 }

--- a/R/merge.R
+++ b/R/merge.R
@@ -33,34 +33,40 @@ merge_edit <- function(
 
   orig_ids = orig2[[names(by)[1]]]
 
-  # only get last edit for each layer id since
-  #   intermediate edits are not important for the final result
-  edits <- aggregate(
-    x = edits,
-    by = list(edits$layerId),
-    FUN = function(x){tail(x,1)},
-    do_union = FALSE
-  )
-
   edit_ids = edits[,by[[1]], drop=TRUE]
 
-  matched_id_rows = which(orig_ids %in% edit_ids)
+  mapply(
+    function(ed, ed_id) {
+      matched_id_row = which(orig_ids == ed_id)
+      st_geometry(orig2)[matched_id_row] <<- st_geometry(st_cast(
+        st_sfc(ed),
+        as.character(st_geometry_type(
+          st_geometry(orig2[matched_id_row,])
+        ))
+      ))
+      return(NULL)
+    },
+    st_geometry(edits),
+    edit_ids
+  )
+
+  #matched_id_rows = which(orig_ids %in% edit_ids)
 
   # cast edits to original type
-  sf::st_geometry(edits) <- sf::st_sfc(mapply(
-    function(ed, type) {
-      sf::st_cast(ed, type)
-    },
-    sf::st_geometry(edits),
-    as.character(
-      sf::st_geometry_type(
-        sf::st_geometry(orig2)
-      )[matched_id_rows]
-    ),
-    SIMPLIFY = FALSE
-  ))
+  #sf::st_geometry(edits) <- sf::st_sfc(mapply(
+  #  function(ed, type) {
+  #    sf::st_cast(ed, type)
+  #  },
+  #  sf::st_geometry(edits),
+  #  as.character(
+  #    sf::st_geometry_type(
+  #      sf::st_geometry(orig2)
+  #    )[matched_id_rows]
+  #  ),
+  #  SIMPLIFY = FALSE
+  #))
 
-  sf::st_geometry(orig2)[matched_id_rows] <- sf::st_geometry(edits)
+  #sf::st_geometry(orig2)[matched_id_rows] <- sf::st_geometry(edits)
   orig2
 }
 

--- a/R/merge.R
+++ b/R/merge.R
@@ -38,15 +38,15 @@ merge_edit <- function(
   mapply(
     function(ed, ed_id) {
       matched_id_row = which(orig_ids == ed_id)
-      st_geometry(orig2)[matched_id_row] <<- st_geometry(st_cast(
-        st_sfc(ed),
-        as.character(st_geometry_type(
-          st_geometry(orig2[matched_id_row,])
+      sf::st_geometry(orig2)[matched_id_row] <<- sf::st_geometry(sf::st_cast(
+        sf::st_sfc(ed),
+        as.character(sf::st_geometry_type(
+          sf::st_geometry(orig2[matched_id_row,])
         ))
       ))
       return(NULL)
     },
-    st_geometry(edits),
+    sf::st_geometry(edits),
     edit_ids
   )
 


### PR DESCRIPTION
This should mostly fix problems discussed in #48 especially when combined with https://github.com/r-spatial/sf/commit/d503aaf985ea86ce941a2c2a96ca2362fbce71c9.

### Discussion

The internal function `fix_geojson_coords()` was built to convert various forms of `GeoJSON` before I learned that `sf::read_sf` handles `GeoJSON` really well.  Eliminating `fix_geojson_coords` and depending entirely on `sf::read_sf` provides more robust and better `GeoJSON` to `sf` conversion.
