### PR TITLE
label argument for selectFeatures and editFeatures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ### New Features
 
-* add `CRS` in `edit*` functions; thx @tim-salabim 
+* add `CRS` in `edit*` functions; thx @tim-salabim
+
+* add label for reference in `edit*` and `select*`
 
 # mapedit 0.3.2
 

--- a/R/edit.R
+++ b/R/edit.R
@@ -152,7 +152,8 @@ editFeatures.sf = function(
     x = mapview:::checkAdjustProjection(x)
     map = mapview::mapview()@map
     map = mapview::addFeatures(
-      map, data=x, layerId=~x$edit_id, label=label,
+      map, data=x, layerId=~x$edit_id,
+      label=label, labelOptions=labelOptions(direction="top"),
       group = "toedit"
     )
     ext = mapview:::createExtent(x)

--- a/R/edit.R
+++ b/R/edit.R
@@ -132,6 +132,8 @@ editFeatures = function(x, ...) {
 #'          of add, edit, delete.
 #' @param record \code{logical} to record all edits for future playback.
 #' @param viewer \code{function} for the viewer.  See Shiny \code{\link[shiny]{viewer}}.
+#' @param label \code{character} vector or \code{formula} for the
+#'          content that will appear in label/tooltip.
 #' @export
 editFeatures.sf = function(
   x,
@@ -140,6 +142,7 @@ editFeatures.sf = function(
   record = FALSE,
   viewer = shiny::paneViewer(),
   crs = 4326,
+  label = NULL,
   ...
 ) {
 
@@ -148,7 +151,10 @@ editFeatures.sf = function(
   if (is.null(map)) {
     x = mapview:::checkAdjustProjection(x)
     map = mapview::mapview()@map
-    map = mapview::addFeatures(map, data=x, layerId=~x$edit_id, group = "toedit")
+    map = mapview::addFeatures(
+      map, data=x, layerId=~x$edit_id, label=label,
+      group = "toedit"
+    )
     ext = mapview:::createExtent(x)
     map = leaflet::fitBounds(
       map,
@@ -163,7 +169,7 @@ editFeatures.sf = function(
       map = map@map
     }
     map = mapview::addFeatures(
-      map, data=x, layerId=~x$edit_id,
+      map, data=x, layerId=~x$edit_id, label = label,
       group = "toedit"
     )
   }

--- a/R/edit.R
+++ b/R/edit.R
@@ -153,7 +153,8 @@ editFeatures.sf = function(
     map = mapview::mapview()@map
     map = mapview::addFeatures(
       map, data=x, layerId=~x$edit_id,
-      label=label, labelOptions=labelOptions(direction="top"),
+      label=label,
+      labelOptions=labelOptions(direction="top"),
       group = "toedit"
     )
     ext = mapview:::createExtent(x)
@@ -170,7 +171,9 @@ editFeatures.sf = function(
       map = map@map
     }
     map = mapview::addFeatures(
-      map, data=x, layerId=~x$edit_id, label = label,
+      map, data=x, layerId=~x$edit_id,
+      label=label,
+      labelOptions=labelOptions(direction="top"),
       group = "toedit"
     )
   }

--- a/R/edit.R
+++ b/R/edit.R
@@ -154,7 +154,7 @@ editFeatures.sf = function(
     map = mapview::addFeatures(
       map, data=x, layerId=~x$edit_id,
       label=label,
-      labelOptions=labelOptions(direction="top"),
+      labelOptions=labelOptions(direction="top", offset=c(0,-40)),
       group = "toedit"
     )
     ext = mapview:::createExtent(x)
@@ -173,7 +173,7 @@ editFeatures.sf = function(
     map = mapview::addFeatures(
       map, data=x, layerId=~x$edit_id,
       label=label,
-      labelOptions=labelOptions(direction="top"),
+      labelOptions=labelOptions(direction="top", offset=c(0,-40)),
       group = "toedit"
     )
   }

--- a/R/select.R
+++ b/R/select.R
@@ -51,7 +51,9 @@ selectFeatures.sf = function(
     if(inherits(map, "mapview")) {
       map = map@map
     }
-    map = mapview::addFeatures(map, data=x, layerId=~x$edit_id)
+    map = mapview::addFeatures(
+      map, data=x, layerId=~x$edit_id, label=label
+    )
   }
 
   ind = selectMap(map, viewer=viewer, ...)

--- a/R/select.R
+++ b/R/select.R
@@ -18,12 +18,15 @@ selectFeatures = function(x, ...) {
 #'          the index of selected features rather than the actual
 #'          selected features
 #' @param viewer \code{function} for the viewer.  See Shiny \code{\link[shiny]{viewer}}.
+#' @param label \code{character} vector or \code{formula} for the
+#'          content that will appear in label/tooltip.
 #' @export
 selectFeatures.sf = function(
   x = NULL,
   map = NULL,
   index = FALSE,
   viewer = shiny::paneViewer(),
+  label = NULL,
   ...
 ) {
 
@@ -32,7 +35,9 @@ selectFeatures.sf = function(
 
   if (is.null(map)) {
     map = mapview::mapview()@map
-    map = mapview::addFeatures(map, data=x, layerId=~x$edit_id)
+    map = mapview::addFeatures(
+      map, data=x, layerId=~x$edit_id, label=label
+    )
     ext = mapview:::createExtent(x)
     map = leaflet::fitBounds(
       map,

--- a/man/editFeatures.Rd
+++ b/man/editFeatures.Rd
@@ -11,7 +11,8 @@
 editFeatures(x, ...)
 
 \method{editFeatures}{sf}(x, map = NULL, mergeOrder = c("add", "edit",
-  "delete"), record = FALSE, viewer = shiny::paneViewer(), ...)
+  "delete"), record = FALSE, viewer = shiny::paneViewer(), crs = 4326,
+  ...)
 
 \method{editFeatures}{Spatial}(x, ...)
 }

--- a/man/editFeatures.Rd
+++ b/man/editFeatures.Rd
@@ -12,7 +12,7 @@ editFeatures(x, ...)
 
 \method{editFeatures}{sf}(x, map = NULL, mergeOrder = c("add", "edit",
   "delete"), record = FALSE, viewer = shiny::paneViewer(), crs = 4326,
-  ...)
+  label = NULL, ...)
 
 \method{editFeatures}{Spatial}(x, ...)
 }
@@ -32,6 +32,9 @@ of add, edit, delete.}
 \item{record}{\code{logical} to record all edits for future playback.}
 
 \item{viewer}{\code{function} for the viewer.  See Shiny \code{\link[shiny]{viewer}}.}
+
+\item{label}{\code{character} vector or \code{formula} for the
+content that will appear in label/tooltip.}
 }
 \description{
 Interactively Edit Map Features

--- a/man/editMap.Rd
+++ b/man/editMap.Rd
@@ -13,10 +13,12 @@
 editMap(x, ...)
 
 \method{editMap}{leaflet}(x = NULL, targetLayerId = NULL, sf = TRUE,
-  ns = "mapedit-edit", record = FALSE, viewer = shiny::paneViewer(), ...)
+  ns = "mapedit-edit", record = FALSE, viewer = shiny::paneViewer(),
+  crs = 4326, ...)
 
 \method{editMap}{mapview}(x = NULL, targetLayerId = NULL, sf = TRUE,
-  ns = "mapedit-edit", record = FALSE, viewer = shiny::paneViewer(), ...)
+  ns = "mapedit-edit", record = FALSE, viewer = shiny::paneViewer(),
+  crs = 4326, ...)
 
 \method{editMap}{NULL}(x, ...)
 }

--- a/man/editMod.Rd
+++ b/man/editMod.Rd
@@ -5,7 +5,7 @@
 \title{Shiny Module Server for Geo Create, Edit, Delete}
 \usage{
 editMod(input, output, session, leafmap, targetLayerId = NULL, sf = TRUE,
-  record = FALSE)
+  record = FALSE, crs = 4326)
 }
 \arguments{
 \item{input}{Shiny server function input}

--- a/man/selectFeatures.Rd
+++ b/man/selectFeatures.Rd
@@ -11,7 +11,7 @@
 selectFeatures(x, ...)
 
 \method{selectFeatures}{sf}(x = NULL, map = NULL, index = FALSE,
-  viewer = shiny::paneViewer(), ...)
+  viewer = shiny::paneViewer(), label = NULL, ...)
 
 \method{selectFeatures}{Spatial}(x, ...)
 }
@@ -29,6 +29,9 @@ the index of selected features rather than the actual
 selected features}
 
 \item{viewer}{\code{function} for the viewer.  See Shiny \code{\link[shiny]{viewer}}.}
+
+\item{label}{\code{character} vector or \code{formula} for the
+content that will appear in label/tooltip.}
 }
 \description{
 Interactively Select Map Features


### PR DESCRIPTION
#53 

### selectFeatures

```
library(mapview)
library(mapedit)

selectFeatures(franconia, label=~NAME_ASCI)
selectFeatures(franconia, label=~NAME_ASCI, map=leaflet() %>% addTiles())
selectFeatures(breweries, label=~brewery)
```

### editFeatures

```
library(mapview)
library(mapedit)

editFeatures(franconia[1:4,], label=~NAME_ASCI)
editFeatures(franconia[1:4,], label=~NAME_ASCI, map=leaflet() %>% addTiles())
editFeatures(breweries, label=~brewery)
```

In `editFeatures`, the label will partially cover the `Leaflet.draw` instructions.  Should we change the `offset` or `direction` with `labelOptions`?

![image](https://user-images.githubusercontent.com/837910/28366053-a5f58ed0-6c50-11e7-8d82-52989f7ab4da.png)
