### PR TITLE
Add arguments to editFeatures allowing control over leafpm options

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -202,7 +202,22 @@ editFeatures = function(x, ...) {
 #' @param title \code{string} to customize the title of the UI window.  The default
 #'          is "Edit Map".
 #' @param editor \code{character} either "leaflet.extras" or "leafpm"
-#'
+#' @param pmToolbarOpts \code{list} of supplied arguments to be passed
+#'     on to \code{leafpm::pmToolbarOptions}. The list elements (if
+#'     any) should be among those documented as accepted by
+#'     \code{\link[leafpm]{pmToolbarOptions}}.
+#' @param pmDrawOpts \code{list} of supplied arguments to be passed on
+#'     to \code{leafpm::pmDrawOptions}. The list elements (if any)
+#'     should be among those documented as accepted by
+#'     \code{\link[leafpm]{pmDrawOptions}}.
+#' @param pmEditOpts \code{list} of supplied arguments to be passed on
+#'     to \code{leafpm::pmEditOptions}. The list elements (if any)
+#'     should be among those documented as accepted by
+#'     \code{\link[leafpm]{pmEditOptions}}.
+#' @param pmCutOpts \code{list} of supplied arguments to be passed on
+#'     to \code{leafpm::pmCutOptions}. The list elements (if any)
+#'     should be among those documented as accepted by
+#'     \code{\link[leafpm]{pmCutOptions}}.
 #' @details
 #'   When setting \code{viewer = browserViewer(browser = getOption("browser"))} and
 #'   the systems default browser is Firefox, the browser window will likely not
@@ -224,7 +239,11 @@ editFeatures.sf = function(
   label = NULL,
   title = "Edit Map",
   editor = c("leaflet.extras", "leafpm"),
-  ...
+  ...,
+  pmToolbarOpts = list(),
+  pmDrawOpts = list(),
+  pmEditOpts = list(),
+  pmCutOpts = list()
 ) {
 
   # store original projection of edited object ----
@@ -277,10 +296,18 @@ editFeatures.sf = function(
       map = leafpm::addPmToolbar(
         map,
         targetGroup = "toedit",
-        toolbarOptions = leafpm::pmToolbarOptions(drawCircle = FALSE),
-        drawOptions = leafpm::pmDrawOptions(allowSelfIntersection = FALSE),
-        editOptions = leafpm::pmEditOptions(allowSelfIntersection = FALSE),
-        cutOptions = leafpm::pmCutOptions(allowSelfIntersection = FALSE)
+        toolbarOptions =
+          do.call(leafpm::pmToolbarOptions,
+                  modifyList(list(drawCircle = FALSE), pmToolbarOpts)),
+        drawOptions =
+          do.call(leafpm::pmDrawOptions,
+                  modifyList(list(allowSelfIntersection = FALSE), pmDrawOpts)),
+        editOptions =
+          do.call(leafpm::pmEditOptions,
+                  modifyList(list(allowSelfIntersection = FALSE), pmEditOpts)),
+        cutOptions =
+          do.call(leafpm::pmCutOptions,
+                  modifyList(list(allowSelfIntersection = FALSE), pmCutOpts))
       )
     }
   }

--- a/man/editFeatures.Rd
+++ b/man/editFeatures.Rd
@@ -11,7 +11,8 @@ editFeatures(x, ...)
 \method{editFeatures}{sf}(x, map = NULL, mergeOrder = c("add", "edit",
   "delete"), record = FALSE, viewer = shiny::paneViewer(),
   crs = 4326, label = NULL, title = "Edit Map",
-  editor = c("leaflet.extras", "leafpm"), ...)
+  editor = c("leaflet.extras", "leafpm"), ..., pmToolbarOpts = list(),
+  pmDrawOpts = list(), pmEditOpts = list(), pmCutOpts = list())
 
 \method{editFeatures}{Spatial}(x, ...)
 }
@@ -46,6 +47,26 @@ content that will appear in label/tooltip.}
 is "Edit Map".}
 
 \item{editor}{\code{character} either "leaflet.extras" or "leafpm"}
+
+\item{pmToolbarOpts}{\code{list} of supplied arguments to be passed
+on to \code{leafpm::pmToolbarOptions}. The list elements (if
+any) should be among those documented as accepted by
+\code{\link[leafpm]{pmToolbarOptions}}.}
+
+\item{pmDrawOpts}{\code{list} of supplied arguments to be passed on
+to \code{leafpm::pmDrawOptions}. The list elements (if any)
+should be among those documented as accepted by
+\code{\link[leafpm]{pmDrawOptions}}.}
+
+\item{pmEditOpts}{\code{list} of supplied arguments to be passed on
+to \code{leafpm::pmEditOptions}. The list elements (if any)
+should be among those documented as accepted by
+\code{\link[leafpm]{pmEditOptions}}.}
+
+\item{pmCutOpts}{\code{list} of supplied arguments to be passed on
+to \code{leafpm::pmCutOptions}. The list elements (if any)
+should be among those documented as accepted by
+\code{\link[leafpm]{pmCutOptions}}.}
 }
 \description{
 Interactively Edit Map Features


### PR DESCRIPTION
New arguments `pmToolbarOpts`, `pmDrawOpts`, `pmEditOpts`, and
`pmCutOpts` take lists of arguments that will be passed on to the
corresponding `leafpm` functions. (The elements of `pmToolbarOpts`,
for example, get passed on as supplied arguments to
`leafpm::pmToolbarOptions()`.) This PR addresses (in part) Issue #92 .

(Note that, unless overridden by an element in user-supplied `*Opts`
argument, `editFeatures` retains its current leafpm defaults, such as
`allowSelfIntersection = FALSE`.)

This example demonstrates usage of one of the newly added arguments:

    library(sf)
    library(leaflet)
    library(mapview)
    library(mapedit)
    library(leafpm)
    ## make a polygon for testing
    x <- list(matrix(c(11,0,11,1,12,1,12,0,11,0), ncol=2, byrow=TRUE))
    pp <- st_sf(geom = st_sfc(st_polygon(x)), crs=4326)

    ## Demonstrate `pmDrawOpts` argument usage
    tst <-
    editFeatures(pp, editor = "leafpm",
                 pmDrawOpts = list(snappable = FALSE,
                                   templineStyle = list(color="yellow")))