### PR TITLE
Calls to addFeatures() & addHomeButton() should use leafem package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     htmltools (>= 0.3),
     htmlwidgets,
     jsonlite,
+    leafem,
     leaflet (>= 2.0.1),
     leaflet.extras (>= 1.0),
     leafpm,

--- a/R/edit.R
+++ b/R/edit.R
@@ -1,7 +1,7 @@
 #' Interactively Edit a Map
 #'
 #' @param x \code{leaflet} or \code{mapview} map to edit
-#' @param ... other arguments for \code{mapview::addFeatures()} when
+#' @param ... other arguments for \code{leafem::addFeatures()} when
 #'          using \code{editMap.NULL} or \code{selectFeatures}
 #'
 #' @return \code{sf} simple features or \code{GeoJSON}
@@ -241,7 +241,7 @@ editFeatures.sf = function(
   if (is.null(map)) {
     x = mapview:::checkAdjustProjection(x)
     map = mapview::mapview()@map
-    map = mapview::addFeatures(
+    map = leafem::addFeatures(
       map, data=x, layerId=~x$edit_id,
       label=label,
       labelOptions = leaflet::labelOptions(direction="top", offset=c(0,-40)),
@@ -255,12 +255,12 @@ editFeatures.sf = function(
       lng2 = ext[2],
       lat2 = ext[4]
     )
-    map = mapview::addHomeButton(map = map, ext = ext)
+    map = leafem::addHomeButton(map = map, ext = ext)
   } else {
     if(inherits(map, "mapview")) {
       map = map@map
     }
-    map = mapview::addFeatures(
+    map = leafem::addFeatures(
       map, data=x, layerId=~x$edit_id,
       label=label,
       labelOptions = leaflet::labelOptions(direction="top", offset=c(0,-40)),

--- a/R/select.R
+++ b/R/select.R
@@ -66,7 +66,7 @@ selectFeatures.sf = function(
 
     if (is.null(map)) {
       map = mapview::mapView(...)@map
-      map = mapview::addFeatures(
+      map = leafem::addFeatures(
         map, data = x, layerId = ~x$edit_id, label = label, ...
       )
       ext = mapview:::createExtent(x)
@@ -77,12 +77,12 @@ selectFeatures.sf = function(
         lng2 = ext[2],
         lat2 = ext[4]
       )
-      map = mapview::addHomeButton(map = map, ext = ext)
+      map = leafem::addHomeButton(map = map, ext = ext)
     } else {
       if(inherits(map, "mapview")) {
         map = map@map
       }
-      map = mapview::addFeatures(
+      map = leafem::addFeatures(
         map, data=x, layerId=~x$edit_id, label=label
       )
     }

--- a/man/editMap.Rd
+++ b/man/editMap.Rd
@@ -24,7 +24,7 @@ editMap(x, ...)
 \arguments{
 \item{x}{\code{leaflet} or \code{mapview} map to edit}
 
-\item{...}{other arguments for \code{mapview::addFeatures()} when
+\item{...}{other arguments for \code{leafem::addFeatures()} when
 using \code{editMap.NULL} or \code{selectFeatures}}
 
 \item{targetLayerId}{\code{string} name of the map layer group to use with edit}


### PR DESCRIPTION
Since its commit [13d04d93bb3563](https://github.com/r-spatial/mapview/commit/13d04d93bb3563a9a876c73edb315f83863a6840), **mapview** functions `addFeatures()` & `addHomeButton()` (along with several others) have been moved out of that package and into the **leafem** package. This commit updates all mapedit function calls to those two functions to call them from the **leafem** namespace and to thus avoid the deprecation warnings that calling them from the **mapview** namespace now produces.