### PR TITLE
Make new editorOptions() argument available in drawFeatures

### DIFF
--- a/R/draw.R
+++ b/R/draw.R
@@ -16,6 +16,9 @@
 #'          behaviour in Firefox.
 #' @param title \code{string} to customize the title of the UI window.
 #' @param editor \code{character} either "leaflet.extras" or "leafpm"
+#' @param editorOptions \code{list} of options suitable for passing to
+#'     either \code{leaflet.extras::addDrawToolbar} or
+#'     \code{leafpm::addPmToolbar}.
 #' @param ... additional arguments passed on to \code{\link{editMap}}.
 #'
 #' @details
@@ -35,6 +38,7 @@ drawFeatures = function(map = NULL,
                         viewer = shiny::paneViewer(),
                         title = "Draw Features",
                         editor = c("leaflet.extras", "leafpm"),
+                        editorOptions = list(),
                         ...) {
   res = editMap(x = map,
                 sf = sf,
@@ -42,6 +46,7 @@ drawFeatures = function(map = NULL,
                 viewer = viewer,
                 title = title,
                 editor = editor,
+                editorOptions = editorOptions,
                 ...)
   if (!inherits(res, "sf") && is.list(res)) res = res$finished
   return(res)

--- a/man/drawFeatures.Rd
+++ b/man/drawFeatures.Rd
@@ -6,7 +6,7 @@
 \usage{
 drawFeatures(map = NULL, sf = TRUE, record = FALSE,
   viewer = shiny::paneViewer(), title = "Draw Features",
-  editor = c("leaflet.extras", "leafpm"), ...)
+  editor = c("leaflet.extras", "leafpm"), editorOptions = list(), ...)
 }
 \arguments{
 \item{map}{a background \code{leaflet} or \code{mapview} map
@@ -28,6 +28,10 @@ behaviour in Firefox.}
 \item{title}{\code{string} to customize the title of the UI window.}
 
 \item{editor}{\code{character} either "leaflet.extras" or "leafpm"}
+
+\item{editorOptions}{\code{list} of options suitable for passing to
+either \code{leaflet.extras::addDrawToolbar} or
+\code{leafpm::addPmToolbar}.}
 
 \item{...}{additional arguments passed on to \code{\link{editMap}}.}
 }


### PR DESCRIPTION
@tim-salabim (at https://github.com/r-spatial/mapedit/pull/100#issuecomment-515720867) noted that "the new `editorOptions()` argument is not available in `drawFeatures`". With a few additional lines, this ties up that loose end. 